### PR TITLE
added -g option for sec-group

### DIFF
--- a/awsbuilder.py
+++ b/awsbuilder.py
@@ -404,7 +404,7 @@ MongoDB CAP AWS instance builder for test""")
         const='terminate',
         default=None)
 
-    parser.add_option("--sec-group", dest="secGroup",
+    parser.add_option("-g", "--sec-group", dest="secGroup",
         help="name of security group to use, will create if doesn't exist (With ssh only)",
         default=None)
 


### PR DESCRIPTION
The error output from line 448 indicates that --sec-group should also be -g, probably left out when --group turned into --sec-group
